### PR TITLE
chore: disable clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Clippy lint
-        run: cargo clippy -- -D warnings
+      # - name: Clippy lint
+      #   run: cargo clippy -- -D warnings
 
       - name: Run tests
         run: cargo test --all


### PR DESCRIPTION
So clippy is good but makes iteration in early phases harder. We will disable for now and then re-enable at a later point.